### PR TITLE
Fix line number lookup for classes

### DIFF
--- a/HyREPL/ops/lookup.hy
+++ b/HyREPL/ops/lookup.hy
@@ -92,8 +92,8 @@
 
                ;; class
                (inspect.isclass x)
-               (and (find-class-definition x path :lang lang)
-                    (return {}))
+               (or (find-class-definition x path :lang lang)
+                   1)
 
                ;; other
                :else


### PR DESCRIPTION
## Summary
- fix `get-source-details` so class definitions correctly report source info

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841c9f5919c8326aadb9e9e4fce49ff