### PR TITLE
Fix comment typo in lookup tests

### DIFF
--- a/tests/ops/lookup.hy
+++ b/tests/ops/lookup.hy
@@ -78,7 +78,7 @@
       (print (.format "result: {}" result))
       (assert (= result {})))
 
-    ;; No sigunature case
+    ;; No signature case
     (let [result (get-info session "set")]
       (print (.format "result: {}" result))
       (assert (= (get result "name") "set"))


### PR DESCRIPTION
## Summary
- correct a misspelling in `tests/ops/lookup.hy`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841d0324e7c83269a6b236d2bba0b28