### PR TITLE
Fix PytestReturnNotNoneWarning configuration

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,8 +1,28 @@
 from pathlib import Path
 
 import hy, pytest
+import warnings
 
 NATIVE_TESTS = Path.cwd() / "tests"
+
+# Ignore PytestReturnNotNoneWarning on Pytest versions that define it.
+try:
+    warnings.filterwarnings(
+        "ignore", category=pytest.PytestReturnNotNoneWarning, append=True
+    )
+except AttributeError:
+    # Older Pytest versions do not provide this warning class.
+    pass
+
+
+def pytest_configure(config):
+    """Apply warning filters after Pytest is fully configured."""
+    try:
+        warnings.filterwarnings(
+            "ignore", category=pytest.PytestReturnNotNoneWarning, append=True
+        )
+    except AttributeError:
+        pass
 
 
 def pytest_collect_file(file_path, parent):

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,4 +5,3 @@ filterwarnings =
     once::DeprecationWarning
     once::PendingDeprecationWarning
     ignore::SyntaxWarning
-    ignore::pytest.PytestReturnNotNoneWarning


### PR DESCRIPTION
## Summary
- remove unsupported filter from `setup.cfg`
- ignore `PytestReturnNotNoneWarning` in `conftest.py`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841d2bcb01c8326ae0c0715ed38a5b8