### PR TITLE
Bump Python & pytest versions

### DIFF
--- a/.github/workflows/hyrepl_test.yaml
+++ b/.github/workflows/hyrepl_test.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ from [nREPL Built-in Ops](https://nrepl.org/nrepl/1.3/ops.html)
 - [ ] swap-middleware
 
 ## Usage
-HyREPL requires Python 3.10 and Hy over 0.2.9.
+HyREPL requires Python 3.11 and Hy over 0.2.9.
 
 To install
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 hy>=0.29.0
 hyrule>=0.6.0
 toolz
-pytest
+pytest>=8.3

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 setup(name="HyREPL",
       version="0.2.4",
       install_requires=['hy>=0.29.0', 'hyrule>=0.6.0', 'toolz'],
-      python_requires='>=3.10',
+      python_requires='>=3.11',
       dependency_links=[
           'https://github.com/hylang/hy/archive/master.zip#egg=hy-0.29.0',
       ],


### PR DESCRIPTION
## Summary
- bump supported Python version to 3.11
- require pytest>=8.3
- update workflow to run on Python 3.11

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841d6178cd483268aeef351f573752b