### PR TITLE
Fix failing defop macro test

### DIFF
--- a/tests/ops/defop.hy
+++ b/tests/ops/defop.hy
@@ -70,7 +70,7 @@
                    (except [e hy.errors.HyMacroExpansionError])
                    (else
                      (assert False (.format "Compiling {} should have failed" ~m)))))]
-    `(do ~s)))
+    `(do ~@s)))
 
 (defn test-defop-fail []
   (macroexpand-multi-assert-fail


### PR DESCRIPTION
## Summary
- fix `macroexpand-multi-assert-fail` to unquote-splice the generated forms

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841d7672824832687e4584c103186a7