### PR TITLE
Fix completion order for private names

### DIFF
--- a/HyREPL/ops/completions.hy
+++ b/HyREPL/ops/completions.hy
@@ -77,14 +77,23 @@
                               "type" (object-type k)}))))
       matches)))
 
+;; Sort completion candidates putting private names (starting with "_") last
+(defn sort-matches [matches]
+  (sorted matches
+          :key (fn [d]
+                 (let [cand (.get d "candidate")
+                       parts (.split cand ".")
+                       name (get parts (- (len parts) 1))]
+                   [(.startswith name "_") cand]))))
+
 (defn get-completions [session stem [extra None]]
   (let [comp (TypedCompleter (. session.module __dict__))]
     (cond
       (in "." stem)
-      (.attr-matches comp stem)
+      (sort-matches (.attr-matches comp stem))
 
       True
-      (.global-matches comp stem))))
+      (sort-matches (.global-matches comp stem)))))
 
 ;; completions
 (defop "completions" [session msg transport]

--- a/tests/ops/completions.hy
+++ b/tests/ops/completions.hy
@@ -37,6 +37,11 @@
 
   ;; Functions which could contain kebab-case symbol
   (setv result (get-completions session "tests.ops.sample_module."))
+  ;; ensure private names (starting with "_") are listed last
+  (setv cands (lfor d result (.get d "candidate")))
+  (setv nonpriv (lfor c cands :if (not (.startswith (get (.split c ".") (- (len (.split c ".")) 1)) "_")) c))
+  (setv priv (lfor c cands :if (.startswith (get (.split c ".") (- (len (.split c ".")) 1)) "_") c))
+  (assert (= cands (+ nonpriv priv)))
   (assert (= (lfor d result :if (= (.get d "candidate") "tests.ops.sample_module.hello") d)
              [{"candidate" "tests.ops.sample_module.hello" "type" "function"}]))
   (assert (= (lfor d result :if (= (.get d "candidate") "tests.ops.sample_module.hello-world") d)


### PR DESCRIPTION
## Summary
- sort completion candidates so names beginning with `_` appear last
- add a regression test checking the ordering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841da7914948326b6d80aefdd53c6d5