### PR TITLE
Add SessionRegistry unit tests

### DIFF
--- a/HyREPL/session.hy
+++ b/HyREPL/session.hy
@@ -19,6 +19,8 @@
 
   (defn __init__ [self [module None]]
     (setv self.id (str (uuid4)))
+    ;; Keep backward compatibility with ``self.uuid`` used by server
+    (setv self.uuid self.id)
     (setv self.lock (Lock))
     (when (is module None)
       (setv module (types.ModuleType f"hyrepl-session-{self.id}")))
@@ -67,7 +69,7 @@
 
   (defn remove [self sid]
     (with [self._lock]
-      (del (get self._sessions.pop sid))))
+      (.pop self._sessions sid None)))
 
   (defn list-ids [self]
     (with [self._lock]

--- a/tests/session_registry.hy
+++ b/tests/session_registry.hy
@@ -1,0 +1,30 @@
+(import HyREPL.session [Session SessionRegistry])
+
+(defn test-create-and-get []
+  (let [registry (SessionRegistry)
+        s1 (.create registry)
+        s2 (.create registry)]
+    (assert (isinstance s1 Session))
+    (assert (isinstance s2 Session))
+    (assert (= (.get registry s1.id) s1))
+    (assert (= (.get registry s2.id) s2))
+    (assert (= (set (.list-ids registry)) #{s1.id s2.id}))))
+
+(defn test-get-missing []
+  (let [registry (SessionRegistry)]
+    (assert (is (.get registry "missing") None))))
+
+(defn test-remove []
+  (let [registry (SessionRegistry)
+        s1 (.create registry)
+        s2 (.create registry)]
+    (.remove registry s1.id)
+    (assert (is (.get registry s1.id) None))
+    (assert (= (set (.list-ids registry)) #{s2.id}))))
+
+(defn test-list-ids []
+  (let [registry (SessionRegistry)
+        s1 (.create registry)
+        s2 (.create registry)]
+    (assert (= (set (.list-ids registry)) #{s1.id s2.id}))
+    (assert (= (len (.list-ids registry)) 2))))


### PR DESCRIPTION
## Summary
- add Session.uuid alias for compatibility
- expand registry unit tests to create two sessions

## Testing
- `pytest -q` *(fails: tests/integration_tests.hy::test_multiple_sessions - RuntimeError: Socket is not connected)*

------
https://chatgpt.com/codex/tasks/task_e_68489d7309388326b3bc5b8f18ba00f9