### PR TITLE
Fix session registry reuse when running server as script

### DIFF
--- a/HyREPL/server.hy
+++ b/HyREPL/server.hy
@@ -17,6 +17,15 @@
 ;; Global session registry
 (setv session-registry (SessionRegistry))
 
+;; When this file is executed as a script (e.g. via `hy -m HyREPL.server`),
+;; Python registers the module under the name `__main__`.  Other modules
+;; import it using the package name `HyREPL.server`, which would normally
+;; create a second instance with a separate `session-registry`.  To ensure
+;; a single shared registry, register this module under its package name
+;; when running as `__main__`.
+(when (= __name__ "__main__")
+  (setv (get sys.modules "HyREPL.server") (get sys.modules __name__)))
+
 (defclass ReplServer [TCPServer ThreadingMixIn]
   (setv allow-reuse-address True))
 


### PR DESCRIPTION
## Summary
- register `HyREPL.server` in `sys.modules` when executed as `__main__`
- ensures ops modules imported by name share the same session registry

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848a347a9dc8326b8cff47aa8bb31af