### PR TITLE
Add coverage badge

### DIFF
--- a/.github/workflows/hyrepl_test.yaml
+++ b/.github/workflows/hyrepl_test.yaml
@@ -21,6 +21,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install pytest-cov
     - name: Test with pytest
       run: |
-        pytest tests
+        pytest --cov=HyREPL --cov-report=xml tests
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        file: ./coverage.xml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # HyREPL
 [![HyREPL unit test](https://github.com/masatoi/HyREPL/actions/workflows/hyrepl_test.yaml/badge.svg)](https://github.com/masatoi/HyREPL/actions/workflows/hyrepl_test.yaml)
+[![codecov](https://codecov.io/gh/masatoi/HyREPL/branch/master/graph/badge.svg)](https://codecov.io/gh/masatoi/HyREPL)
 
 HyREPL is an implementation of the [nREPL](https://nrepl.org) protocol for [Hy](https://github.com/hylang/hy).
 


### PR DESCRIPTION
## Summary
- measure coverage on CI and upload to codecov
- show coverage badge in README

## Testing
- `pytest --cov=HyREPL --cov-report=xml -q` *(fails: KeyboardInterrupt after tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_684b136210d08326903d58a519137716