### PR TITLE
Fix completion error handling

### DIFF
--- a/HyREPL/ops/completions.hy
+++ b/HyREPL/ops/completions.hy
@@ -39,7 +39,9 @@
 
 (defn split-by-last-dot [text]
   (let [matches (re.match r"(\S+(\.[\w-]+)*)\.([\w-]*)$" text)]
-    (.group matches 1 3)))
+    (if matches
+        (.group matches 1 3)
+        [text ""])))
 
 (defclass TypedCompleter [hy.completer.Completer]
   (defn attr-matches [self text]

--- a/tests/ops/completions.hy
+++ b/tests/ops/completions.hy
@@ -102,3 +102,9 @@
   (setv result (get-completions session "baz._"))
   (assert (= (lfor d result :if (= (.get d "candidate") "baz._get_y") d)
              [{"candidate" "baz._get_y" "type" "method"}])))
+
+(defn test-get-completions-invalid-prefix []
+  "Completions should not crash on non-Python-like input."
+  (setv session (Session))
+  (setv result (get-completions session "https://example.com/foo"))
+  (assert (= result [])))


### PR DESCRIPTION
## Summary
- avoid AttributeError in completion code by returning default match
- test completions on invalid input

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c3512fe308326aaede56029477d0f