### PR TITLE
test: run CI with multiple hy versions

### DIFF
--- a/.github/workflows/hyrepl_test.yaml
+++ b/.github/workflows/hyrepl_test.yaml
@@ -8,8 +8,11 @@ on:
 
 jobs:
   build:
-
+    name: Hy ${{ matrix.hy-version }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        hy-version: ["0.29.0", "1.0.0", "1.1.0"]
 
     steps:
     - uses: actions/checkout@v2
@@ -20,6 +23,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install hy==${{ matrix.hy-version }}
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Test with pytest
       run: |


### PR DESCRIPTION
## Summary
- run CI across Hy 0.29.0, 1.0.0, and 1.1.0

## Testing
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_68959be939d8832683dd5fe31509da9d